### PR TITLE
Log warning if trying to set hvac mode when setting temperature

### DIFF
--- a/custom_components/bedjet/climate.py
+++ b/custom_components/bedjet/climate.py
@@ -166,9 +166,10 @@ class BedJetClimateEntity(BedJetEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        if kwargs.get(ATTR_HVAC_MODE):
+        if ATTR_HVAC_MODE in kwargs:
             _LOGGER.warning(
-                "Changing HVAC mode while setting temperature is not supported. "
-                "Please call `climate.set_hvac_mode` first"
+                "Changing HVAC mode while setting temperature for %s is not supported. "
+                "Please call `climate.set_hvac_mode` first",
+                self.entity_id,
             )
         await self._device.set_temperature(kwargs.get(ATTR_TEMPERATURE))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when the climate API is used incorrectly — instructs users to set HVAC mode separately before changing temperature; temperature adjustments continue to work as before.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->