### PR TITLE
fix(v2): restore BedJet V2 discovery and connection compatibility

### DIFF
--- a/custom_components/bedjet/config_flow.py
+++ b/custom_components/bedjet/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_ADDRESS
 
 from .const import DOMAIN
-from .pybedjet import BEDJET2_SERVICE_UUID, BEDJET3_SERVICE_UUID, BedJet
+from .pybedjet import BEDJET3_SERVICE_UUID, BedJet
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,10 +116,7 @@ class BedjetDeviceConfigFlow(ConfigFlow, domain=DOMAIN):
                     or discovery.address in self._discovered_devices
                     or not (
                         BEDJET3_SERVICE_UUID in discovery.service_uuids
-                        or (
-                            discovery.name
-                            and discovery.name.startswith(LOCAL_NAME)
-                        )
+                        or (discovery.name and discovery.name.startswith(LOCAL_NAME))
                     )
                 ):
                     continue

--- a/custom_components/bedjet/config_flow.py
+++ b/custom_components/bedjet/config_flow.py
@@ -117,7 +117,7 @@ class BedjetDeviceConfigFlow(ConfigFlow, domain=DOMAIN):
                     or not (
                         BEDJET3_SERVICE_UUID in discovery.service_uuids
                         or (
-                            BEDJET2_SERVICE_UUID in discovery.service_uuids
+                            discovery.name
                             and discovery.name.startswith(LOCAL_NAME)
                         )
                     )

--- a/custom_components/bedjet/pybedjet/__init__.py
+++ b/custom_components/bedjet/pybedjet/__init__.py
@@ -567,17 +567,25 @@ class BedJet:
                     bytearray([0x58, 0x01, 0x0B, 0x9B]),
                     response=False,
                 )
+                await asyncio.sleep(3.0)
             else:
                 self._is_v2 = False
                 status_uuid = BEDJET3_STATUS_UUID
 
             _LOGGER.debug("%s: Subscribe to notifications", self.name_and_address)
 
-            await client.start_notify(
-                status_uuid,
-                self._notification_handler,
-                cb={"notification_discriminator": self._notification_check_handler},
-            )
+            for attempt in range(3):
+                try:
+                    await client.start_notify(
+                        status_uuid,
+                        self._notification_handler,
+                        cb={"notification_discriminator": self._notification_check_handler},
+                    )
+                    break
+                except Exception:
+                    if attempt == 2:
+                        raise
+                    await asyncio.sleep(1.0)
 
             if not self._is_v2:
                 if self._device_status_data is None:

--- a/custom_components/bedjet/pybedjet/__init__.py
+++ b/custom_components/bedjet/pybedjet/__init__.py
@@ -579,7 +579,9 @@ class BedJet:
                     await client.start_notify(
                         status_uuid,
                         self._notification_handler,
-                        cb={"notification_discriminator": self._notification_check_handler},
+                        cb={
+                            "notification_discriminator": self._notification_check_handler
+                        },
                     )
                     break
                 except Exception:


### PR DESCRIPTION
Restores BedJet V2 compatibility, both discovery and interaction, that was broken after v2.0.0.

Tested on BedJet V2 hardware:
- Advertised name: `BEDJET`
- Service UUID: `49535343-fe7d-4ae5-8fa9-9fafd205e455`
- Module: ISSC

**Test sequence confirmed working:**
- Fresh install → auto-discovery ✓
- Delete integration → rediscover → re-pair ✓
- Temperature updates ✓
- Mode changes (Heat, Cool, Turbo) ✓

---

## Changes

### 'custom_components/bedjet/pybedjet/__init__.py'
- Restore 'await asyncio.sleep(3.0)' after V2 wake-up packet
- Restore 'start_notify' retry loop (3 attempts, 1s delay between retries)

### 'custom_components/bedjet/config_flow.py'
- Restore name-based discovery filter: accept any device whose advertised name starts with `"BEDJET"`, regardless of advertised service UUIDs

---

## Testing Checklist - Strictly V2 Hardware

- [x] Fresh install - auto-discovery works
- [x] Delete and re-discover - device found and paired successfully
- [x] Temperature and status update correctly
- [x] Heat, Cool, and Turbo modes work
- [x] BedJet 3 should not be effected, no changes to V3 code paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced BedJet device discovery to support BedJet 3 devices and improved name-based device identification
  * Improved connection reliability with retry logic for device notifications
  * Optimized V2 device initialization timing for more stable handshaking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/natekspencer/ha-bedjet/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->