### PR TITLE
Fix discovery for BedJet advertisements without service UUIDs

### DIFF
--- a/custom_components/bedjet/manifest.json
+++ b/custom_components/bedjet/manifest.json
@@ -10,6 +10,10 @@
       "local_name": "BEDJET",
       "service_uuid": "49535343-fe7d-4ae5-8fa9-9fafd205e455",
       "connectable": true
+    },
+    {
+      "local_name": "BEDJET*",
+      "connectable": true
     }
   ],
   "codeowners": [


### PR DESCRIPTION
## Summary

Adds a name-only Bluetooth discovery fallback for BedJet devices that advertise as `BEDJET` but do not include service UUIDs in their BLE advertisement.

I observed a BedJet advertisement in Home Assistant through an ESP32 Bluetooth proxy with:

```json
{
  "name": "BEDJET",
  "address": "8C:DE:52:C2:51:EA",
  "service_uuids": [],
  "connectable": true
}
```

The current V2 Bluetooth manifest matcher requires both `local_name: BEDJET` and the ISSC service UUID, so this advertisement is visible in Home Assistant but does not trigger the integration’s Bluetooth discovery flow.

The manual config flow already accepts discovered devices where the name starts with `BEDJET`, so this makes the manifest matcher consistent with that fallback.

## Changes

- Adds a `BEDJET*` connectable Bluetooth matcher without requiring a service UUID.

## Testing

- Validated `custom_components/bedjet/manifest.json` with `python -m json.tool`.
- Tested the equivalent change locally through HACS against a BedJet advertisement that had `name: BEDJET` and an empty `service_uuids` list.