### PR TITLE
Fix preset_modes capability-update-loop warning

### DIFF
--- a/custom_components/bedjet/climate.py
+++ b/custom_components/bedjet/climate.py
@@ -136,7 +136,11 @@ class BedJetClimateEntity(BedJetEntity, ClimateEntity):
         if device.is_v2 and self._attr_preset_mode is None:
             self._attr_preset_mode = "None"
 
-        self._attr_preset_modes = (
+        # Only reassign preset_modes when it actually changes (e.g. once
+        # memory/biorhythm names are read after connecting). Reassigning an
+        # equivalent list on every poll trips HA's "updating capabilities too
+        # often" warning even though the value never changes in practice.
+        preset_modes = (
             base_presets
             + [
                 name
@@ -153,6 +157,8 @@ class BedJetClimateEntity(BedJetEntity, ClimateEntity):
                 if name
             ]
         )
+        if preset_modes != self._attr_preset_modes:
+            self._attr_preset_modes = preset_modes
         self._attr_target_temperature = state.target_temperature
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:


### PR DESCRIPTION
ClimateEntity capability attrs (hvac_modes, fan_modes, supported_features) were already static, but _attr_preset_modes was rebuilt into a new list object on every _async_update_attrs() call (i.e. every poll), even though the underlying memory/biorhythm names only change once after the BLE connection is established. Reassigning an equal-valued list every poll trips HA's "is updating its capabilities ... too often" warning.

Only reassign preset_modes when the computed value actually differs from the current one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device stability by reducing unnecessary capability update warnings and notifications. Preset mode configurations are now handled more efficiently during polling operations. The system no longer generates alerts when preset settings remain consistent, resulting in fewer distracting notifications and a cleaner, more stable overall experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->